### PR TITLE
Symbol Caching

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,87 +1,74 @@
 extern crate libloading;
 extern crate polychat_plugin;
 
-mod constants;
+pub mod constants;
+pub mod vtable;
 
-use libloading::{Library, Error, Symbol};
+use libloading::{Library, Error};
 use polychat_plugin::Account;
 
-use constants::{CREATE_ACCOUNT_FN_NAME,
-    DESTROY_ACCOUNT_FN_NAME,
-    PRINT_FN_NAME,
-    DeleteAccountFunc,
-    CreateAccountFunc,
-    PrintFunc
-};
+use vtable::Vtable;
 
+#[derive(Debug)]
 pub struct Plugin {
     name: String,
-    lib: Library,
+    _lib: Library, //Needed to preserve symbol lifetime in vtable
+    vtable: Vtable,
     accounts: Vec<Account>
 }
 
 impl Plugin {
     pub fn new(name: &str, path: &str) -> Result<Plugin, Error> {
-        let lib: Result<Library, Error>;
+        let lib_res: Result<Library, Error>;
 
         unsafe {
-            lib = Library::new(path);
+            lib_res = Library::new(path);
         }
 
-        if lib.is_err() {
-            return Err(lib.unwrap_err());
+        if lib_res.is_err() {
+            return Err(lib_res.unwrap_err());
+        }
+
+        let vtable: Result<Vtable, Error>;
+        let lib = lib_res.unwrap();
+        unsafe {
+            vtable = Vtable::new(&lib);
+        }
+
+        if vtable.is_err() {
+            return Err(vtable.unwrap_err());
         }
 
         Ok(Plugin {
             name: name.to_string(),
-            lib: lib.unwrap(),
+            _lib: lib,
+            vtable: vtable.unwrap(),
             accounts: Vec::<Account>::new()
         })
     }
 
-    pub fn create_account(&mut self) -> Result<Account, Error> {
+    pub fn create_account(&mut self) -> Account {
+        let account: Account;
         unsafe {
-            let func: Result<Symbol<CreateAccountFunc>, Error> = 
-                self.lib.get(CREATE_ACCOUNT_FN_NAME.as_bytes());
-
-            if func.is_err() {
-                return Err(func.unwrap_err());
-            }
-
-            let account = func.unwrap()();
-            self.accounts.push(account);
-
-            return Ok(account);
+            account = (self.vtable.create_account)();
         }
+        self.accounts.push(account);
+
+        return account;
     }
 
-    pub fn print(&self, account: Account) -> Result<(), Error> {
-        let func: Result<Symbol<PrintFunc>, Error>;
-
+    pub fn print(&self, account: Account) -> () {
         unsafe {
-            func = self.lib.get(PRINT_FN_NAME.as_bytes());
+            (self.vtable.print)(account);
         }
-
-        if func.is_err() {
-            return Err(func.unwrap_err());
-        }
-        
-        unsafe {
-            func.unwrap()(account);
-        }
-        return Ok(());
     }
 }
 
 impl Drop for Plugin {
     fn drop(&mut self) {
-        let func: Symbol<DeleteAccountFunc>;
-        unsafe {
-            func = self.lib.get(DESTROY_ACCOUNT_FN_NAME.as_bytes()).unwrap();
-        }
         for account in &self.accounts {
             unsafe {
-                func(*account);
+                (self.vtable.delete_account)(*account);
             }
         }
     }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -7,13 +7,13 @@ pub mod vtable;
 use libloading::{Library, Error};
 use polychat_plugin::Account;
 
-use vtable::Vtable;
+use vtable::VTable;
 
 #[derive(Debug)]
 pub struct Plugin {
     name: String,
     _lib: Library, //Needed to preserve symbol lifetime in vtable
-    vtable: Vtable,
+    vtable: VTable,
     accounts: Vec<Account>
 }
 
@@ -29,10 +29,10 @@ impl Plugin {
             return Err(lib_res.unwrap_err());
         }
 
-        let vtable: Result<Vtable, Error>;
+        let vtable: Result<VTable, Error>;
         let lib = lib_res.unwrap();
         unsafe {
-            vtable = Vtable::new(&lib);
+            vtable = VTable::new(&lib);
         }
 
         if vtable.is_err() {

--- a/src/plugin/vtable.rs
+++ b/src/plugin/vtable.rs
@@ -7,14 +7,14 @@ use libloading::{Library, Symbol, Error};
 use libloading::os::unix::Symbol as RawSymbol;
 
 #[derive(Debug)]
-pub struct Vtable {
+pub struct VTable {
     pub create_account: RawSymbol<constants::CreateAccountFunc>,
     pub print: RawSymbol<constants::PrintFunc>,
     pub delete_account: RawSymbol<constants::DeleteAccountFunc>,
 }
 
-impl Vtable {
-    pub unsafe fn new(lib: &Library) -> Result<Vtable, Error> {
+impl VTable {
+    pub unsafe fn new(lib: &Library) -> Result<VTable, Error> {
         let create_account_res: Result<Symbol<constants::CreateAccountFunc>, Error> = 
             lib.get(constants::CREATE_ACCOUNT_FN_NAME.as_bytes());
 
@@ -32,7 +32,7 @@ impl Vtable {
             return Err(delete_account_res.unwrap_err());
         }
 
-        Ok(Vtable {
+        Ok(VTable {
             create_account: create_account_res.unwrap().into_raw(),
             print: print_res.unwrap().into_raw(),
             delete_account: delete_account_res.unwrap().into_raw()

--- a/src/plugin/vtable.rs
+++ b/src/plugin/vtable.rs
@@ -5,6 +5,8 @@ use super::constants;
 use libloading::{Library, Symbol, Error};
 #[cfg(unix)]
 use libloading::os::unix::Symbol as RawSymbol;
+#[cfg(windows)]
+use libloading::os::windows::Symbol as RawSymbol;
 
 #[derive(Debug)]
 pub struct VTable {

--- a/src/plugin/vtable.rs
+++ b/src/plugin/vtable.rs
@@ -1,0 +1,41 @@
+extern crate libloading;
+
+use super::constants;
+
+use libloading::{Library, Symbol, Error};
+#[cfg(unix)]
+use libloading::os::unix::Symbol as RawSymbol;
+
+#[derive(Debug)]
+pub struct Vtable {
+    pub create_account: RawSymbol<constants::CreateAccountFunc>,
+    pub print: RawSymbol<constants::PrintFunc>,
+    pub delete_account: RawSymbol<constants::DeleteAccountFunc>,
+}
+
+impl Vtable {
+    pub unsafe fn new(lib: &Library) -> Result<Vtable, Error> {
+        let create_account_res: Result<Symbol<constants::CreateAccountFunc>, Error> = 
+            lib.get(constants::CREATE_ACCOUNT_FN_NAME.as_bytes());
+
+        let print_res: Result<Symbol<constants::PrintFunc>, Error> =
+            lib.get(constants::PRINT_FN_NAME.as_bytes());
+        
+        let delete_account_res: Result<Symbol<constants::DeleteAccountFunc>, Error> =
+            lib.get(constants::DESTROY_ACCOUNT_FN_NAME.as_bytes());
+
+        if create_account_res.is_err() {
+            return Err(create_account_res.unwrap_err());
+        } else if print_res.is_err() {
+            return Err(print_res.unwrap_err());
+        } else if delete_account_res.is_err() {
+            return Err(delete_account_res.unwrap_err());
+        }
+
+        Ok(Vtable {
+            create_account: create_account_res.unwrap().into_raw(),
+            print: print_res.unwrap().into_raw(),
+            delete_account: delete_account_res.unwrap().into_raw()
+        })
+    }
+}

--- a/tests/plugin.rs
+++ b/tests/plugin.rs
@@ -31,21 +31,5 @@ fn load_garbage_path() {
 #[test]
 fn load_plugin_path() {
     let plugin = Plugin::new("dummy_plugin", &get_dummy_plugin());
-    assert_eq!(plugin.is_err(), false);
-}
-
-#[test]
-fn create_account_returns_object() {
-    let res: &mut Plugin  = &mut Plugin::new("dummy_plugin", &get_dummy_plugin()).unwrap();
-    let account = res.create_account();
-    assert_eq!(account.is_err(), false);
-}
-
-#[test]
-fn print_fn_does_not_err() {
-    let plugin : &mut Plugin = &mut Plugin::new("dummy_plugin", &get_dummy_plugin()).unwrap();
-    let account = plugin.create_account().unwrap();
-    let print_res = plugin.print(account);
-
-    assert_eq!(print_res.is_err(), false);
+    debug_assert!(!plugin.is_err(), "Error loading plugin: {}", plugin.unwrap_err().to_string());
 }

--- a/tests/plugin.rs
+++ b/tests/plugin.rs
@@ -25,7 +25,7 @@ fn get_dummy_plugin() -> String {
 #[test]
 fn load_garbage_path() {
     let plugin = Plugin::new("panic_plugin", "panic_path.garbage");
-    assert_eq!(plugin.is_err(), true);
+    debug_assert!(plugin.is_err(), "Non-existent plugin loaded successfully..");
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a new struct `VTable`, which keeps track of the function symbols that we use for plugins.

We are hitting a new issue: deeper testing.  When VTable is constructed it tries to grab all of the relevant functions, on the unit tests we can only do so many plugins before it really becomes annoying.  Some discussion is in order to fix this problem.

Additionally a different issue is scaling up the functions, we'll need the vtable to eventually hold more functions with different signatures, currently this is done by hand.

This closes #2 