### PR TITLE
Logging, some cleanup, and Documentation!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polychat-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ crate-type = ["rlib", "dylib"]
 [dependencies]
 libloading = "0.7.3"
 polychat-plugin = "0.2.0"
+log = "0.4.14"

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -2,7 +2,7 @@ extern crate libloading;
 extern crate polychat_plugin;
 
 use libloading::{Library, Error};
-use log::{info, warn, debug};
+use log::{info, warn};
 
 use polychat_plugin::plugin::{InitializedPlugin, PluginInfo, INITIALIZE_FN_NAME};
 use polychat_plugin::types::Account;
@@ -26,46 +26,19 @@ impl Plugin {
     /// explaining the root cause in an Err type.
     pub fn new(path: &str) -> Result<Plugin, String> {
         let lib_res: Result<Library, Error>;
-        info!("Loading lib {}", path);
+        info!("[{}] Loading lib", path);
         unsafe {
             lib_res = Library::new(path);
         }
         
         match lib_res {
             Err(error) => { // Library Errored out
-                warn!("Library ({}) failed to load: {}", path, error.to_string());
+                warn!("[{}] Library failed to load: {}", path, error.to_string());
                 return Err(error.to_string());
             },
             Ok(lib) => {
-                info!("Successfully loaded library {}", path);
-                info!("Loading \"{}\" symbol for initialization", INITIALIZE_FN_NAME);
-
-                match unsafe { lib.get::<InitFn>(INITIALIZE_FN_NAME.as_bytes()) } {
-                    Err(error) => { // Finding initialize symbol errored out
-                        warn!("Failed to load \"{}\" symbol in {}: {}", INITIALIZE_FN_NAME, path, error.to_string());
-                        return Err(error.to_string());
-                    },
-                    Ok(func) => {
-                        info!("Sucessfully loaded symbol \"{}\"", INITIALIZE_FN_NAME);
-                        info!("Calling \"{}\"", INITIALIZE_FN_NAME);
-                        let mut plugin_info = PluginInfo::new();
-                        func(&mut plugin_info);
-                        info!("Initializing plugin");
-                        match InitializedPlugin::new(&plugin_info) {
-                            Err(err) => { // PluginInfo is missing info :(
-                                warn!("Could not initialize plugin: {}", err);
-                                return Err(err);
-                            },
-                            Ok(plugin) => {
-                                info!("Successfully initialized plugin");
-                                return Ok(Plugin {
-                                    _lib: lib,
-                                    plugin_info: plugin
-                                });
-                            }
-                        }
-                    }
-                }
+                info!("[{}] Successfully loaded library", path);
+                return new_from_loaded_lib(path, lib);
             }
         }
     }
@@ -80,5 +53,35 @@ impl Plugin {
 
     pub fn print(&self, account: Account) {
         (self.plugin_info.print)(account);
+    }
+}
+
+fn new_from_loaded_lib(path: &str, lib: Library) -> Result<Plugin, String>{
+    info!("Loading \"{}\" symbol for initialization", INITIALIZE_FN_NAME);
+
+    match unsafe { lib.get::<InitFn>(INITIALIZE_FN_NAME.as_bytes()) } {
+        Err(error) => { // Finding initialize symbol errored out
+            warn!("Failed to load \"{}\" from {} symbol: {}", INITIALIZE_FN_NAME, path, error.to_string());
+            return Err(error.to_string());
+        },
+        Ok(func) => {
+            info!("[{}] Sucessfully loaded symbol \"{}\"", path, INITIALIZE_FN_NAME);
+            info!("[{}] Calling \"{}\"", path, INITIALIZE_FN_NAME);
+
+            let mut plugin_info = PluginInfo::new();
+            func(&mut plugin_info);
+
+            info!("[{}] Initializing plugin", path);
+            let init_plugin_res = InitializedPlugin::new(&plugin_info); 
+            
+            if init_plugin_res.is_err() {
+                return Err(init_plugin_res.unwrap_err());
+            }
+
+            return Ok(Plugin {
+                _lib: lib,
+                plugin_info: init_plugin_res.unwrap()
+            });
+        }
     }
 }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -10,11 +10,19 @@ type InitFn = fn (thing: *mut PluginInfo);
 
 #[derive(Debug)]
 pub struct Plugin {
-    _lib: Library, //Needed to preserve symbol lifetime in vtable
+    _lib: Library, //Needed to preserve symbol lifetime in plugin_info
     plugin_info: InitializedPlugin
 }
 
 impl Plugin {
+    /// Creates an initialized Plugin
+    /// 
+    /// # Arguments
+    /// * path - A string slice for an absolute path to a library file (dll/so/dynlib)
+    /// 
+    /// # Errors
+    /// If a Plugin cannot be initialized, a string is returned 
+    /// explaining the root cause in an Err type.
     pub fn new(path: &str) -> Result<Plugin, String> {
         let lib_res: Result<Library, Error>;
 

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -16,13 +16,13 @@ pub struct Plugin {
 }
 
 impl Plugin {
-    /// Creates an initialized Plugin
+    /// Creates an initialized Plugin, ready for use
     /// 
     /// # Arguments
     /// * path - A string slice for an absolute path to a library file (dll/so/dynlib)
     /// 
     /// # Errors
-    /// If a Plugin cannot be initialized, a string is returned 
+    /// If a Plugin cannot be initialized for any reason, a string is returned 
     /// explaining the root cause in an Err type.
     pub fn new(path: &str) -> Result<Plugin, String> {
         let lib_res: Result<Library, Error>;


### PR DESCRIPTION
This PR adds the `log` crate as a dependency so we can put debug information into the console as we need it.

Added docstring comment to `Plugin::new`, `cargo doc` will build documentation from that.

Cleaned up `Plugin::new` again to be less of a nested mess.

This closes #10 and closes #4 