### PR TITLE
Message communication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["rlib", "dylib"]
 
 [dependencies]
 libloading = "0.7.3"
-polychat-plugin = "0.2.0"
+polychat-plugin = "0.3.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["rlib", "dylib"]
 
 [dependencies]
 libloading = "0.7.3"
-polychat-plugin = { path = "../polychat-plugin" }
+polychat-plugin = "0.3.0"
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ crate-type = ["rlib", "dylib"]
 
 [dependencies]
 libloading = "0.7.3"
-polychat-plugin = "0.3.0"
+polychat-plugin = { path = "../polychat-plugin" }
 log = "0.4.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polychat-core"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -5,7 +5,7 @@ use std::ffi::CString;
 use libloading::{Library, Error};
 use log::{info, warn};
 
-use polychat_plugin::plugin::{InitializedPlugin, PluginInfo, INITIALIZE_FN_NAME, Message};
+use polychat_plugin::plugin::{InitializedPlugin, PluginInfo, INITIALIZE_FN_NAME, Message, SendStatus};
 use polychat_plugin::types::Account;
 
 type InitFn = fn (thing: *mut PluginInfo);
@@ -52,12 +52,12 @@ impl Plugin {
         (self.plugin_info.destroy_account)(account);
     }
 
-    pub fn post_message(&self, msg_body: String) {
+    pub fn post_message(&self, msg_body: String) -> SendStatus {
         let body_cstr = CString::new(msg_body).unwrap();
         let msg = Message {
             body: body_cstr.as_ptr()
         };
-        (self.plugin_info.post_message)(&msg);
+        return (self.plugin_info.post_message)(&msg);
     }
 
     pub fn print(&self, account: Account) {

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1,10 +1,11 @@
 extern crate libloading;
 extern crate polychat_plugin;
 
+use std::ffi::CString;
 use libloading::{Library, Error};
 use log::{info, warn};
 
-use polychat_plugin::plugin::{InitializedPlugin, PluginInfo, INITIALIZE_FN_NAME};
+use polychat_plugin::plugin::{InitializedPlugin, PluginInfo, INITIALIZE_FN_NAME, Message};
 use polychat_plugin::types::Account;
 
 type InitFn = fn (thing: *mut PluginInfo);
@@ -49,6 +50,14 @@ impl Plugin {
 
     pub fn delete_account(&self, account: Account) {
         (self.plugin_info.destroy_account)(account);
+    }
+
+    pub fn post_message(&self, msg_body: String) {
+        let body_cstr = CString::new(msg_body).unwrap();
+        let msg = Message {
+            body: body_cstr.as_ptr()
+        };
+        (self.plugin_info.post_message)(&msg);
     }
 
     pub fn print(&self, account: Account) {

--- a/tests/dummy_plugin/Cargo.toml
+++ b/tests/dummy_plugin/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-polychat-plugin = "0.3.0"
+polychat-plugin = { path = "../../../polychat-plugin" }
 libc = "0.2.113"

--- a/tests/dummy_plugin/Cargo.toml
+++ b/tests/dummy_plugin/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-polychat-plugin = "0.2.0"
+polychat-plugin = "0.3.0"
 libc = "0.2.113"

--- a/tests/dummy_plugin/Cargo.toml
+++ b/tests/dummy_plugin/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-polychat-plugin = { path = "../../../polychat-plugin" }
+polychat-plugin = "0.3.0"
 libc = "0.2.113"

--- a/tests/dummy_plugin/dummy_plugin.rs
+++ b/tests/dummy_plugin/dummy_plugin.rs
@@ -7,6 +7,7 @@ use std::boxed::Box;
 use polychat_plugin::types::Account;
 use polychat_plugin::plugin::PluginInfo;
 use polychat_plugin::plugin::Message;
+use polychat_plugin::plugin::SendStatus;
 
 extern "C" fn create_account() -> Account {
     Box::into_raw(Box::new(5)) as Account
@@ -19,10 +20,11 @@ extern "C" fn print(acc: Account) {
     }
 }
 
-extern "C" fn post_message(msg: * const Message) {
+extern "C" fn post_message(msg: * const Message) -> SendStatus {
     unsafe {
         println!("Instructed to post message with body {}", *(*msg).body);
     }
+    return SendStatus::Sending;
 }
 
 extern "C" fn destroy_account(acc: Account) {

--- a/tests/dummy_plugin/dummy_plugin.rs
+++ b/tests/dummy_plugin/dummy_plugin.rs
@@ -6,6 +6,7 @@ use std::boxed::Box;
 
 use polychat_plugin::types::Account;
 use polychat_plugin::plugin::PluginInfo;
+use polychat_plugin::plugin::Message;
 
 extern "C" fn create_account() -> Account {
     Box::into_raw(Box::new(5)) as Account
@@ -15,6 +16,12 @@ extern "C" fn print(acc: Account) {
     let data = acc as *mut u8;
     unsafe {
         println!("Hello {}", *data);
+    }
+}
+
+extern "C" fn post_message(msg: * const Message) {
+    unsafe {
+        println!("Instructed to post message with body {}", *(*msg).body);
     }
 }
 
@@ -28,5 +35,6 @@ extern "C" fn destroy_account(acc: Account) {
 unsafe extern "C" fn initialize(info: *mut PluginInfo) {
     (*info).create_account = Some(create_account);
     (*info).destroy_account = Some(destroy_account);
+    (*info).post_message = Some(post_message);
     (*info).print = Some(print);
 }


### PR DESCRIPTION
Dependent on the pull request in polychat-plugin.

This pull request adds the interface to interact with the plugin's post_message function, which uses a c-string. This converts the standard rust string to a c-string.
This pull request also adds the new function to the dummy plugin.