### PR TITLE
Plugin manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ crate-type = ["rlib", "dylib"]
 
 [dependencies]
 libloading = "0.7.3"
-polychat-plugin = "0.3.0"
+polychat-plugin = "0.3.1"
 log = "0.4.14"
 walkdir = "2.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ crate-type = ["rlib", "dylib"]
 libloading = "0.7.3"
 polychat-plugin = "0.3.0"
 log = "0.4.14"
+walkdir = "2.3.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod plugin;
+pub mod plugin_manager;

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -63,6 +63,10 @@ impl Plugin {
     pub fn print(&self, account: Account) {
         (self.plugin_info.print)(account);
     }
+
+    pub fn get_name(&self) -> &String {
+        &self.plugin_info.name
+    }
 }
 
 fn new_from_loaded_lib(path: &str, lib: Library) -> Result<Plugin, String>{

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -69,17 +69,13 @@ impl PluginManager {
 
     pub fn create_account(&mut self, service_name: &str) -> Result<Account, &str>  {
         let name = service_name.to_string();
-
-        if !self.plugin_map.contains_key(&name) {
-            debug!("Could not create account for service {}", name);
-            return Err("No such service");
-        }
-        let plugin = self.plugin_map.get(&name).unwrap(); //Guarenteed since we already checked with contains_key
+        let plugin = get_plugin(&self.plugin_map, service_name)?;
         
         let account = plugin.create_account();
         
         let vec = self.account_map.entry(name).or_insert(Vec::<Account>::new());
         vec.push(account);
+        debug!("Created account {:p} at index {} for {}", account, vec.len() - 1, service_name);
 
         return Ok(account);
     }
@@ -96,9 +92,9 @@ impl PluginManager {
                 return Err("Could not find associated account");
             },
             Some(index) => {
+                debug!("Removing account {:p} at index {} for plugin {}", account, index, name);
                 vector.remove(index);
                 plugin.delete_account(account);
-                debug!("Removed account at index {} for plugin {}", index, name);
             }
         }
         

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -23,6 +23,7 @@ const DYN_LIB_EXTENSION: &str = "dll";
 type PluginMap = HashMap<String, Plugin>;
 type AccountMap = HashMap<String, Vec<Account>>;
 
+#[derive(Debug)]
 pub struct PluginManager {
     plugin_map: PluginMap,
     account_map: AccountMap,

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -16,7 +16,7 @@ use crate::plugin::Plugin;
 #[cfg(target_os = "linux")]
 const DYN_LIB_EXTENSION: &str = "so";
 #[cfg(target_os = "macos")]
-const DYN_LIB_EXTENSION: &str = "dynlib";
+const DYN_LIB_EXTENSION: &str = "dylib";
 #[cfg(target_os = "windows")]
 const DYN_LIB_EXTENSION: &str = "dll";
 

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -30,12 +30,22 @@ pub struct PluginManager {
 }
 
 impl PluginManager {
+    #[allow(rustdoc::private_intra_doc_links)]
+    /**
+     * Creates a new PluginManager based off the provided path
+     * 
+     * All plugins must fit the criteria of [is_expected_file]
+     * 
+     * This returns an `Err` when [check_directory](check_directory) would fail.
+     */
     pub fn new(dir: &Path) -> Result<PluginManager, &str> {
-        check_directory(dir)?;
+        check_directory(dir)?; //Check to ensure that we can load from the directory
         let mut plugin_map = PluginMap::new();
-
+        
+        //Walk through the directory, ignore symlinks
         let iter = WalkDir::new(dir).max_depth(2).min_depth(2).follow_links(false).into_iter();
 
+        //Filter the entries to be what we expect
         for plugin_item in iter.filter_entry(|e| is_expected_file(e)) {
             if let Ok(plugin_item) = plugin_item {
                 let path = plugin_item.path().to_str().unwrap_or("Unknown Path");
@@ -45,6 +55,8 @@ impl PluginManager {
                 match plugin_res {
                     Ok(plugin) => {
                         let name = plugin.get_name();
+
+                        //If a duplicate entry is found, do not override the previous one
                         if plugin_map.contains_key(name) {
                             warn!("Duplicate plugin name {}, using the first one found", name);
                         } else {
@@ -63,17 +75,32 @@ impl PluginManager {
         })
     }
     
+    /**
+     * Creates a PluginManager from a string slice.
+     * 
+     * Does the exact same thing as [new](#method.new)
+     */
     pub fn from(path: &str) -> Result<PluginManager, &str> {
         let dir = Path::new(path);
         PluginManager::new(dir)
     }
 
+    /**
+     * Creates an account with the associated service.
+     * 
+     * If the plugin does not exist, an Err is returned with
+     * a string slice explaining the issue.
+     * 
+     * All accounts are stored and dropped once PluginManager gets dropped,
+     * so there is no need to do this independently of this module
+     */
     pub fn create_account(&mut self, service_name: &str) -> Result<Account, &str>  {
         let name = service_name.to_string();
         let plugin = get_plugin(&self.plugin_map, service_name)?;
         
         let account = plugin.create_account();
         
+        //Get the existing vector entry or create it if it doesn't exist
         let vec = self.account_map.entry(name).or_insert(Vec::<Account>::new());
         vec.push(account);
         debug!("Created account {:p} at index {} for {}", account, vec.len() - 1, service_name);
@@ -81,6 +108,14 @@ impl PluginManager {
         return Ok(account);
     }
 
+    #[allow(rustdoc::private_intra_doc_links)]
+    /**
+     * Removes an account from the associated service account store.
+     * 
+     * If any of the following conditions are met, an Err is returned with an explanatory string slice.
+     * - The account does not exist within the account store
+     * - There is no plugin with the provided `service_name` (see [get_plugin](get_plugin))
+     */
     pub fn delete_account(&mut self, service_name: &str, account: Account) -> Result<(), &str> {
         let name = service_name.to_string();
         let plugin = get_plugin(&self.plugin_map, service_name)?;
@@ -102,6 +137,10 @@ impl PluginManager {
         return Ok(());
     }
 
+    /**
+     * Returns a vector of services that the PluginManager 
+     * currently supports.
+     */
     pub fn get_services(&self) -> Vec<String> {
         let mut output: Vec<String> = Vec::<String>::new();
 
@@ -127,6 +166,13 @@ impl Drop for PluginManager {
     }
 }
 
+/**
+ * Gets the plugin from the HashMap with the
+ * provided service_name.
+ * 
+ * If the plugin does not exist, a warning is logged and an
+ * `Err` with a string slice is returned explaining the error
+ */
 fn get_plugin<'map>(plugin_map: &'map PluginMap, service_name: &str) -> Result<&'map Plugin, &'static str> {
     return match plugin_map.get(service_name) {
         None => {
@@ -137,6 +183,13 @@ fn get_plugin<'map>(plugin_map: &'map PluginMap, service_name: &str) -> Result<&
     };
 }
 
+/**
+ * Gets the account vector from the HashMap with
+ * the provided service_name.
+ * 
+ * If the vector does not exist, a warning is logged and an
+ * `Err` with a string slice is returned explaining the error.
+ */
 fn get_account_vec<'map>(account_map: &'map mut AccountMap, service_name: &str) -> Result<&'map mut Vec<Account>, &'static str> {
     return match account_map.get_mut(service_name) {
         None => {
@@ -147,12 +200,33 @@ fn get_account_vec<'map>(account_map: &'map mut AccountMap, service_name: &str) 
     };
 }
 
+/**
+ * Checks a DirectoryEntry to see if it is a 
+ * dynamic library that PluginManager can load.
+ * 
+ * Current criteria:
+ * - Must be a file (kinda hard to dynamically load a folder)
+ * - The extension must match [DYN_LIB_EXTENSION], which is defined
+ * on a per-operating system basis
+ */
 fn is_expected_file(entry: &DirEntry) -> bool {
     let ext = entry.path().extension().unwrap_or(OsStr::new("Unknown"));
 
     return entry.path().is_file() && ext == DYN_LIB_EXTENSION;
 }
 
+/**
+ * Checks the provided path to see if it
+ * meets the criteria needed for PluginManager.
+ * The criteria is:
+ * - Must actually exist
+ * - Must be a directory
+ * - Must be an absolute path
+ * 
+ * If any of the above criteria are not met, an error
+ * is logged and an `Err` is returned with a string slice
+ * explaining the error.
+ */
 fn check_directory(dir: &Path) -> Result<(), &str> {
     let str_path = dir.to_str().unwrap_or("Unknown path");
     if !dir.is_absolute() {

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -1,7 +1,7 @@
 extern crate polychat_plugin;
 extern crate walkdir;
 
-use std::{ffi::OsStr, thread::AccessError};
+use std::ffi::OsStr;
 use std::collections::HashMap;
 use std::path::Path;
 use walkdir::{WalkDir, DirEntry};

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -1,0 +1,66 @@
+extern crate polychat_plugin;
+
+use std::{collections::HashMap, fs::ReadDir};
+use std::path::Path;
+
+use polychat_plugin::types::Account;
+use log::{info, warn, error};
+
+use crate::plugin::Plugin;
+
+pub struct PluginManager {
+    plugin_map: HashMap<String, Plugin>,
+    account_map: HashMap<String, Account>
+}
+
+impl PluginManager {
+    pub fn new(dir: &Path) -> Result<PluginManager, &str> {
+        let dir_check = check_directory(dir);
+
+        if dir_check.is_err() {
+            return Err(dir_check.unwrap_err());
+        }
+
+        for entry in dir_check.unwrap() {
+            if let Ok(entry) = entry {
+                info!("Found {}", entry.path().to_str().expect("Could not decode path"));
+            }
+        }
+
+        Ok(PluginManager {
+            plugin_map: HashMap::<String, Plugin>::new(),
+            account_map: HashMap::<String, Account>::new()
+        })
+    }
+    
+    pub fn from(path: &str) -> Result<PluginManager, &str> {
+        let dir = Path::new(path);
+        PluginManager::new(dir)
+    }
+}
+
+fn check_directory(dir: &Path) -> Result<ReadDir, &str> {
+    let str_path = dir.to_str().unwrap_or("Unknown path");
+    if !dir.is_absolute() {
+        error!("Path {} is not absolute", str_path);
+        return Err("Path must be absolute");
+    }
+    if !dir.exists() {
+        error!("Directory {} does not exist", str_path);
+        return Err("Directory does not exist");
+    }
+    if !dir.is_dir() {
+        error!("Path {} is not a directory", str_path);
+        return Err("Path is not a directory");
+    }
+
+    let read_dir_res = dir.read_dir();
+
+    if read_dir_res.is_err() {
+        let err = read_dir_res.unwrap_err();
+        error!("Could not read directory {}: {}", str_path, err.to_string());
+        return Err("Could not read directory");
+    }
+
+    Ok(read_dir_res.unwrap())
+}

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -1,9 +1,11 @@
 extern crate polychat_plugin;
 extern crate walkdir;
 
-use std::ffi::OsStr;
-use std::collections::HashMap;
-use std::path::Path;
+use std::{ 
+    ffi::OsStr,
+    collections::HashMap,
+    path::Path
+};
 use walkdir::{WalkDir, DirEntry};
 
 use polychat_plugin::types::Account;

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -93,7 +93,7 @@ impl PluginManager {
             },
             Some(index) => {
                 debug!("Removing account {:p} at index {} for plugin {}", account, index, name);
-                vector.remove(index);
+                vector.swap_remove(index);
                 plugin.delete_account(account);
             }
         }

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -11,8 +11,12 @@ use log::{debug, error};
 
 use crate::plugin::Plugin;
 
-#[cfg(unix)]
+#[cfg(target_os = "linux")]
 const DYN_LIB_EXTENSION: &str = "so";
+#[cfg(target_os = "macos")]
+const DYN_LIB_EXTENSION: &str = "dynlib";
+#[cfg(target_os = "windows")]
+const DYN_LIB_EXTENSION: &str = "dll";
 
 pub struct PluginManager {
     plugin_map: HashMap<String, Plugin>,

--- a/src/plugin_manager/mod.rs
+++ b/src/plugin_manager/mod.rs
@@ -112,6 +112,16 @@ impl PluginManager {
         
         return Ok(());
     }
+
+    pub fn get_services(&self) -> Vec<String> {
+        let mut output: Vec<String> = Vec::<String>::new();
+
+        for (key, _) in &self.plugin_map {
+            output.push(key.clone());
+        }
+
+        return output;
+    }
 }
 
 impl Drop for PluginManager {

--- a/tests/dummy_plugin/Cargo.toml
+++ b/tests/dummy_plugin/Cargo.toml
@@ -12,5 +12,5 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-polychat-plugin = "0.3.0"
+polychat-plugin = "0.3.1"
 libc = "0.2.113"

--- a/tests/dummy_plugin/dummy_plugin.rs
+++ b/tests/dummy_plugin/dummy_plugin.rs
@@ -2,7 +2,7 @@ extern crate libc;
 extern crate polychat_plugin;
 
 use std::boxed::Box;
-
+use std::ffi::CString;
 
 use polychat_plugin::types::Account;
 use polychat_plugin::plugin::PluginInfo;
@@ -35,6 +35,7 @@ extern "C" fn destroy_account(acc: Account) {
 
 #[no_mangle]
 unsafe extern "C" fn initialize(info: *mut PluginInfo) {
+    (*info).name = CString::new("dummy").expect("Could not create CString").into_raw();
     (*info).create_account = Some(create_account);
     (*info).destroy_account = Some(destroy_account);
     (*info).post_message = Some(post_message);

--- a/tests/plugin_manager.rs
+++ b/tests/plugin_manager.rs
@@ -1,0 +1,79 @@
+use polychat_core::plugin_manager::PluginManager;
+
+use std::path::PathBuf;
+use std::env;
+
+fn get_dummy_plugin() -> String {
+    PathBuf::from(
+        env::var("CARGO_MANIFEST_DIR").unwrap()
+    ).join("tests")
+        .join("dummy_plugin")
+        .join("target")
+        .join("debug").display().to_string()
+}
+
+#[test]
+fn load_non_absolute_path() {
+    let plugin_manager = PluginManager::from("target");
+    debug_assert!(plugin_manager.is_err(), "Plugin manager loaded from a non-absolute directory..");
+}
+
+#[test]
+fn load() {
+    let path = get_dummy_plugin();
+    let plugin_manager = PluginManager::from(path.as_str());
+    debug_assert!(plugin_manager.is_ok(), "Error loading plugin: {}", plugin_manager.unwrap_err());
+}
+
+#[test]
+fn create_account_for_non_existent_plugin() {
+    let path = get_dummy_plugin();
+    let mut plugin_manager = PluginManager::from(path.as_str()).unwrap();
+
+    let account = plugin_manager.create_account("garbage");
+
+    debug_assert!(account.is_err(), "Plugin manager found a garbage plugin... We might want to update this test");
+}
+
+#[test]
+fn create_account_for_existing_plugin() {
+    let path = get_dummy_plugin();
+    let mut plugin_manager = PluginManager::from(path.as_str()).unwrap();
+
+    let account = plugin_manager.create_account("dummy");
+
+    debug_assert!(account.is_ok(), "Unable to create account for dummy plugin: {}", account.unwrap_err());
+}
+
+#[test]
+fn destroy_account_for_non_existent_plugin() {
+    let path = get_dummy_plugin();
+    let mut plugin_manager = PluginManager::from(path.as_str()).unwrap();
+
+    let account = plugin_manager.create_account("dummy").unwrap();
+
+    let res = plugin_manager.delete_account("garbage", account);
+
+    debug_assert!(res.is_err(), "PluginManager found a garbage plugin AND/OR passed the wrong Account to it to be freed");
+}
+
+#[test]
+fn double_free_never_happens() {
+    let path = get_dummy_plugin();
+    let mut plugin_manager = PluginManager::from(path.as_str()).unwrap();
+    let account = plugin_manager.create_account("dummy").unwrap();
+
+    plugin_manager.delete_account("dummy", account).unwrap();
+    let double_free = plugin_manager.delete_account("dummy", account);
+
+    debug_assert!(double_free.is_err(), "Plugin manager double free'd an account");
+}
+
+#[test]
+fn get_services_returns_services() {
+    let path = get_dummy_plugin();
+    let plugin_manager = PluginManager::from(path.as_str()).unwrap();
+    let services = plugin_manager.get_services();
+
+    assert_eq!(services, ["dummy"]);
+}


### PR DESCRIPTION
This adds in a plugin manager, which will search a directory for .so/.dynlib/.dll files and then load them all into a hashmap.  This also keeps track of the accounts created for each plugin and frees them accordingly when the account is deleted or the PluginManager goes out of scope (when the core shuts down).

This closes #9.